### PR TITLE
Adjust formatting macro usage for compatibility with future Rust compiler versions

### DIFF
--- a/crates/noil/src/output.rs
+++ b/crates/noil/src/output.rs
@@ -38,19 +38,18 @@ pub async fn get_outputs(path: &Path, no_color: bool) -> anyhow::Result<String> 
     for (prefix, individual_prefix, path) in paths {
         let path_str = path.display().to_string();
         let mut line = String::new();
+        let prefix_with_color = if no_color {
+            prefix
+        } else if let Some(suffix) = prefix.strip_prefix(individual_prefix) {
+            //&format!("*{individual_prefix}*{suffix}")
+            &format!("{individual_prefix}{suffix}")
+        } else {
+            prefix
+        };
         write!(
             &mut line,
             "   {}{}   :   {}{}",
-            {
-                if no_color {
-                    prefix
-                } else if let Some(suffix) = prefix.strip_prefix(individual_prefix) {
-                    //&format!("*{individual_prefix}*{suffix}")
-                    &format!("{individual_prefix}{suffix}")
-                } else {
-                    prefix
-                }
-            },
+            prefix_with_color,
             " ".repeat(shortest_len - prefix.len()),
             path_str,
             {


### PR DESCRIPTION
Hi! This project turned up when assessing the impact of an upcoming Rust compiler bugfix, rust-lang/rust#145838. Currently, formatting macros can cause borrowed temporaries within block tail expressions within their arguments to live longer than they normally would in Rust 2024[^1]. Unfortunately, fixing that inconsistency is a breaking change and this project no longer compiles as-is after the fix. This PR implements a minimal change to address the future error.

For reference, here's the build failure log: https://crater-reports.s3.amazonaws.com/pr-145838/try%23b83b707f97d809763b7861afa7638871f3339a33/gh/kjuulh.noil/log.txt

[^1]: See https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html for further details on the expected temporary scope of block tail expressions.
